### PR TITLE
changed gradients dict to OrderedDict

### DIFF
--- a/sb/sb_resnet.py
+++ b/sb/sb_resnet.py
@@ -299,7 +299,7 @@ def run_ResNet(dataset,
     else:
         print "No! Starting from scratch."
 
-    gradients = dict(zip(params, T.grad(cost, params)))
+    gradients = OrderedDict(zip(params, T.grad(cost, params)))
 
     if gradient_clipping is not None:
         grad_norm = T.sqrt(sum(map(lambda d: T.sqr(d).sum(), gradients.values())))


### PR DESCRIPTION
Hi @MarcCote,
We have used this code as a benchmark for Theano development. Using Theano's profiling, when running this code on the same version of Theano, the timing is slightly different. Thus, it could not be used to see how a fix in Theano has affected the timing. 

We looked for any randomness in ```sb_resnet.py```. The problem is in using ```dict``` for storing the ```gradients``` as iterating through a dict is not deterministic between different executions. Thus, changing the ```dict``` to an ```OrderedDict``` makes ```sb_resnet.py``` deterministic. This pull request addresses this issue. You can see a trace of how we found the problem in here: Theano/Theano#5477.